### PR TITLE
docs: fix dead link to job-worker connector rt

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Run unit tests
 mvn clean verify
 ```
 
-Use the [Camunda Job Worker Connector Run-Time](https://github.com/camunda/connector-framework/tree/main/runtime-job-worker) to run your function as a local Job Worker.
+Use the [Camunda Job Worker Connector Run-Time](https://github.com/camunda/connector-sdk/tree/main/runtime) to run your function as a local Job Worker.
 
 ## Element Template
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Fixes the link in [README.md](https://github.com/camunda/connector-template/blob/574cd989b1f8d848514d5ec408cdb60cce26d20d/README.md?plain=1#L53) to [Camunda Job Worker Connector Run-Time](https://github.com/camunda/connector-sdk/tree/main/runtime).

## Related issues

<!-- Which issues are closed by this PR or are related -->

No related issues.

