### PR TITLE
feat: bump SDK to 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ provides more details on relocations.
 }
 ```
 
+### Error codes
+
+| Code | Description |
+| - | - |
+| FAIL | Message starts with 'fail' (ignoring case) |
+
 ## Test locally
 
 Run unit tests

--- a/element-templates/template-connector.json
+++ b/element-templates/template-connector.json
@@ -30,6 +30,10 @@
     {
       "id": "output",
       "label": "Output Mapping"
+    },
+    {
+      "id": "errors",
+      "label": "Error Handling"
     }
   ],
   "properties": [
@@ -100,6 +104,17 @@
       "binding": {
         "type": "zeebe:taskHeader",
         "key": "resultExpression"
+      }
+    },
+    {
+      "label": "Error Expression",
+      "description": "Expression to define BPMN Errors to throw",
+      "group": "errors",
+      "type": "Text",
+      "feel": "required",
+      "binding": {
+        "type": "zeebe:taskHeader",
+        "key": "errorExpression"
       }
     }
   ]

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <!-- connector SDK version -->
-    <version.connector-core>0.2.2</version.connector-core>
+    <version.connector-core>0.3.0</version.connector-core>
 
     <!-- external libraries -->
     <version.assertj>3.23.1</version.assertj>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <!-- connector SDK version -->
-    <version.connector-core>0.3.0.alpha2</version.connector-core>
+    <version.connector-core>0.3.0-alpha2</version.connector-core>
 
     <!-- external libraries -->
     <version.assertj>3.23.1</version.assertj>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <!-- connector SDK version -->
-    <version.connector-core>0.3.0</version.connector-core>
+    <version.connector-core>0.3.0.alpha2</version.connector-core>
 
     <!-- external libraries -->
     <version.assertj>3.23.1</version.assertj>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <!-- connector SDK version -->
-    <version.connector-core>0.3.0-alpha2</version.connector-core>
+    <version.connector-core>0.3.0</version.connector-core>
 
     <!-- external libraries -->
     <version.assertj>3.23.1</version.assertj>

--- a/src/main/java/io/camunda/connector/Authentication.java
+++ b/src/main/java/io/camunda/connector/Authentication.java
@@ -1,8 +1,8 @@
 package io.camunda.connector;
 
 import io.camunda.connector.api.annotation.Secret;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.Pattern;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Pattern;
 
 import java.util.Objects;
 

--- a/src/main/java/io/camunda/connector/MyConnectorFunction.java
+++ b/src/main/java/io/camunda/connector/MyConnectorFunction.java
@@ -1,6 +1,7 @@
 package io.camunda.connector;
 
 import io.camunda.connector.api.annotation.OutboundConnector;
+import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import org.slf4j.Logger;
@@ -27,8 +28,12 @@ public class MyConnectorFunction implements OutboundConnectorFunction {
   private MyConnectorResult executeConnector(final MyConnectorRequest connectorRequest) {
     // TODO: implement connector logic
     LOGGER.info("Executing my connector with request {}", connectorRequest);
+    String message = connectorRequest.getMessage();
+    if (message != null && message.toLowerCase().startsWith("fail")) {
+      throw new ConnectorException("FAIL", "My property started with 'fail', was: " + message);
+    }
     var result = new MyConnectorResult();
-    result.setMyProperty("Message received: " + connectorRequest.getMessage());
+    result.setMyProperty("Message received: " + message);
     return result;
   }
 }

--- a/src/main/java/io/camunda/connector/MyConnectorRequest.java
+++ b/src/main/java/io/camunda/connector/MyConnectorRequest.java
@@ -1,9 +1,9 @@
 package io.camunda.connector;
 
 import io.camunda.connector.api.annotation.Secret;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
+import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 
 import java.util.Objects;
 

--- a/src/test/java/io/camunda/connector/MyFunctionTest.java
+++ b/src/test/java/io/camunda/connector/MyFunctionTest.java
@@ -1,7 +1,9 @@
 package io.camunda.connector;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
+import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.test.outbound.OutboundConnectorContextBuilder;
 import org.junit.jupiter.api.Test;
 
@@ -27,5 +29,27 @@ public class MyFunctionTest {
       .isInstanceOf(MyConnectorResult.class)
       .extracting("myProperty")
       .isEqualTo("Message received: Hello World!");
+  }
+
+  @Test
+  void shouldThrowWithErrorCodeWhenMessageStartsWithFail() {
+    // given
+    var input = new MyConnectorRequest();
+    var auth = new Authentication();
+    input.setMessage("Fail: unauthorized");
+    input.setAuthentication(auth);
+    auth.setToken("xobx-test");
+    auth.setUser("testuser");
+    var function = new MyConnectorFunction();
+    var context = OutboundConnectorContextBuilder.create()
+        .variables(input)
+        .build();
+    // when
+    var result = catchThrowable(() -> function.execute(context));
+    // then
+    assertThat(result)
+        .isInstanceOf(ConnectorException.class)
+        .hasMessageContaining("started with 'fail'")
+        .extracting("errorCode").isEqualTo("FAIL");
   }
 }


### PR DESCRIPTION
## Description

* Bumps SDK to `0.3.0`
* Adds error codes to Connector function
* Adds error handling to element template
* Adjusts validation annotations from `jakarta.validation` to `javax.validation`

## Related issues

related to https://github.com/camunda/team-connectors/issues/203
