### PR TITLE
chore(template): update to connector & camunda 8.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <version.connectors>8.8.7</version.connectors>
-    <version.camunda>8.8.16</version.camunda>
+    <version.connectors>8.9.0</version.connectors>
+    <version.camunda>8.9.0</version.camunda>
     <version.assertj>3.27.4</version.assertj>
     <version.junit-jupiter>6.0.2</version.junit-jupiter>
     <version.awaitility>4.2.0</version.awaitility>

--- a/src/test/java/io/camunda/example/integration/TestConnectorRuntimeApplication.java
+++ b/src/test/java/io/camunda/example/integration/TestConnectorRuntimeApplication.java
@@ -1,17 +1,9 @@
 package io.camunda.example.integration;
 
 import io.camunda.client.annotation.Deployment;
-import io.camunda.connector.api.document.DocumentFactory;
-import io.camunda.connector.runtime.core.document.DocumentFactoryImpl;
-import io.camunda.connector.runtime.core.document.store.InMemoryDocumentStore;
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Primary;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootApplication
 @Deployment(resources = "classpath*:/bpmn/**/*.bpmn")
-public class TestConnectorRuntimeApplication { }
+public class TestConnectorRuntimeApplication {
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,6 +1,6 @@
 # Configuration for running connectors locally in bundle with connector-runtime
 server.port=9898
 camunda.client.grpc-address=http://localhost:26500
-camunda.client.rest-address=http://localhost:8088
+camunda.client.rest-address=http://localhost:8080
 camunda.connector.polling.enabled=false
 


### PR DESCRIPTION
This pull request updates dependencies to the latest Camunda and connectors versions, cleans up the test application class, and fixes a configuration property for the test environment.

Dependency upgrades:

* Updated Camunda and connectors versions in `pom.xml` from `8.8.x` to `8.9.0` to ensure compatibility with the latest platform features and bug fixes.

Test configuration improvements:

* Changed the `camunda.client.rest-address` in `application.properties` from port `8088` to the default port `8080` to align with standard local development setups.

Code cleanup:

* Removed unused imports and annotations from `TestConnectorRuntimeApplication.java` for a cleaner and more maintainable test application class.