### PR TITLE
chore(template): add documents management and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,187 +1,360 @@
-> A Connector template for new C8 outbound connector
->
-> To use this template update the following resources to match the name of your connector:
->
-> * [README](./README.md) (title, description)
-> * [POM](./pom.xml) (artifact name, id, description)
-> * [Connector](src/main/java/io/camunda/example/MyConnector.java) (rename, implement, update
-    `OutboundConnector` annotation)
-> * [Service Provider Interface (SPI)](./src/main/resources/META-INF/services/io.camunda.connector.api.outbound.OutboundConnectorProvider) (
-    adapt to your connector class)
-> * [Element Template](./element-templates/my-connector.json) (will be generated during build)
->
-> about [creating Connectors](https://docs.camunda.io/docs/components/connectors/custom-built-connectors/connector-sdk/#creating-a-custom-connector)
->
-> Check out the [Connectors SDK](https://github.com/camunda/connectors)
+# Connector Template — Camunda 8 Outbound Connector
 
-# Connector Template
+A starter template for building a custom **outbound** connector with the Camunda Connector SDK.
+The example uses the **annotations-based Operations API**, which lets a single connector class
+expose multiple operations (here: `echo`, `addTwoNumbers`, `processDocument`).
 
-Camunda Outbound Connector Template
+> Looking for the inbound counterpart? See the
+> [connector-template-inbound](https://github.com/camunda/connector-template-inbound) repo.
 
-This repository provides a template for creating a Camunda Outbound Connector using the Connector SDK. 
-The example is using the annotations-based approach that allows to define multiple operations within a single Connector.
+---
 
-## Operations API - `OutboundConnectorProvider`
+## Contents
 
-Example implementation: [`io.camunda.example.MyConnector`](src/main/java/io/camunda/example/MyConnector.java).
+- [Use this template](#use-this-template)
+- [5-minute Quickstart](#5-minute-quickstart)
+- [Operations API vs Classic Function API — which to pick](#operations-api-vs-classic-function-api--which-to-pick)
+- [Build](#build)
+- [Run locally](#run-locally)
+  - [Local Connector Runtime (recommended for development)](#local-connector-runtime-recommended-for-development)
+  - [Bundled Docker runtime (closer to production)](#bundled-docker-runtime-closer-to-production)
+  - [SaaS](#saas)
+- [Testing](#testing)
+- [Document handling](#document-handling)
+- [Element template — tips and do/don't](#element-template--tips-and-dodont)
+- [Web Modeler vs Desktop Modeler](#web-modeler-vs-desktop-modeler)
+- [Troubleshooting](#troubleshooting)
+- [Versions and compatibility](#versions-and-compatibility)
 
-This example leverages the `@Operation` annotation to define multiple operations within a single Connector class. 
-The example defines two operations - `echo` and `addTwoNumbers` - each represented by a method annotated with `@Operation`.
-Each operation method accepts an input parameter annotated with `@Variable` (or `@Header`) and returns an output object.
+---
 
-The runtime uses the `OutboundConnectorProvider` interface to discover and instantiate the Connector. If you rename your
-Connector class, make sure to update the corresponding entry in the `META-INF/services/io.camunda.connector.api.outbound.OutboundConnectorProvider` file.
+## Use this template
 
-Another example implementation for an annotations-based Connector is the [CSV Connector](https://github.com/camunda/connectors/blob/main/connectors/csv/src/main/java/io/camunda/connector/csv/CsvConnector.java).
+Click **Use this template** on GitHub, then rename in the new repo:
+
+| File | What to change |
+|---|---|
+| `pom.xml` | `<artifactId>`, `<name>`, `<description>`, `<groupId>` if needed |
+| `src/main/java/io/camunda/example/MyConnector.java` | rename class; update `@OutboundConnector(name, type)` and `@ElementTemplate(id, name, version, description, icon, documentationRef)` |
+| `src/main/resources/META-INF/services/io.camunda.connector.api.outbound.OutboundConnectorProvider` | match new fully-qualified class name (one line) |
+| `src/main/resources/icon.svg` | replace with your icon |
+| `pom.xml` element-template-generator config (`<connectorClass>`, `<templateId>`, `<templateFileName>`) | match new connector class and template id |
+| `README.md`, `LICENSE` | your project metadata |
+
+The element template (`element-templates/<your-template>.json`) is **regenerated** by `mvn package`,
+do not edit it by hand.
+
+See the official guide on [creating a custom connector](https://docs.camunda.io/docs/components/connectors/custom-built-connectors/connector-sdk/).
+
+---
+
+## 5-minute Quickstart
+
+```bash
+# 1. clone your fork
+git clone https://github.com/<you>/<your-connector>.git
+cd <your-connector>
+
+# 2. build, run unit + integration tests, generate element template
+mvn clean package
+
+# 3. start the local runtime (uses an embedded Camunda for testing)
+mvn -Dexec.mainClass=io.camunda.example.LocalConnectorRuntime test-compile exec:java
+```
+
+Then upload `element-templates/my-connector.json` to your Modeler, drop a service task, and pick
+**My Connector Template**. See [Run locally](#run-locally) for the full picture.
+
+---
+
+## Operations API vs Classic Function API — which to pick
+
+The SDK supports two styles. **Default to the Operations API** unless you have a reason not to.
+
+| | **Operations API** (`OutboundConnectorProvider` + `@Operation`) | **Classic Function API** (`OutboundConnectorFunction.execute`) |
+|---|---|---|
+| Multiple operations per connector | Native — one `@Operation` per method, dispatched via the `operation` header | Manual — you switch on a discriminator field yourself |
+| Variable binding | Per-parameter (`@Variable`, `@Header`) — typed | You call `context.bindVariables(MyInput.class)` |
+| Element template | Generated from `@TemplateProperty` on each operation's input record | Generated from a single input record |
+| Boilerplate | Less | More |
+| When you'd pick it | Most new connectors. Good fit when the connector wraps an API with several actions (HTTP-style: GET / POST / DELETE) | Single-purpose connectors, or when migrating an older connector and the rewrite isn't worth it |
+
+This template uses the Operations API — see
+[`MyConnector`](src/main/java/io/camunda/example/MyConnector.java). For a real-world example
+covering more patterns, look at the
+[CSV Connector](https://github.com/camunda/connectors/blob/main/connectors/csv/src/main/java/io/camunda/connector/csv/CsvConnector.java).
+
+If you do want the Classic style, change the class to `implements OutboundConnectorFunction`,
+update the SPI file to point at `io.camunda.connector.api.outbound.OutboundConnectorFunction`,
+and remove `@Operation` annotations.
+
+---
 
 ## Build
-
-You can package the Connector by running the following command:
 
 ```bash
 mvn clean package
 ```
 
-This will create the following artifacts:
+Produces:
+- a thin JAR
+- a fat JAR (shaded). SDK artifacts are in `<scope>provided</scope>` and supplied by the runtime.
+- the regenerated element template under `element-templates/`.
 
-- A thin JAR without dependencies.
-- A fat JAR containing all dependencies, potentially shaded to avoid classpath conflicts. This will not include the SDK
-  artifacts since those are in scope `provided` and will be brought along by the respective Connector Runtime executing
-  the Connector.
+### Shading
 
-### Shading dependencies
+`maven-shade-plugin` is preconfigured. Add `<relocations>` for libraries you ship that the runtime
+also bundles (most commonly **Jackson**). Otherwise you'll see classpath errors like:
 
-You can use the `maven-shade-plugin` defined in the [Maven configuration](./pom.xml) to relocate common dependencies
-that are used in other Connectors and
-the [Connector Runtime](https://github.com/camunda/connectors).
-This helps to avoid classpath conflicts when the Connector is executed.
-
-
-For example, without shading, you might encounter errors like:
 ```
-java.lang.NoSuchMethodError: com.fasterxml.jackson.databind.ObjectMapper.setserializationInclusion(Lcom/fasterxml/jackson/annotation/JsonInclude$Include;)Lcom/fasterxml/jackson/databind/ObjectMapper;
-```
-This occurs when your connector and the runtime use different versions of the same library (e.g., Jackson).
-
-Use the `relocations` configuration in the Maven Shade plugin to define the dependencies that should be shaded.
-The [Maven Shade documentation](https://maven.apache.org/plugins/maven-shade-plugin/examples/class-relocation.html)
-provides more details on relocations.
-
-## API
-
-### Input
-
-| Name    | Description      | Example           | Notes                                                                      |
-|---------|------------------|-------------------|----------------------------------------------------------------------------|
-| user    | Mock username    | `alice`           | Has no effect on the function call outcome.                                |
-| token   | Mock token value | `my-secret-token` | Has no effect on the function call outcome.                                |
-| message | Mock message     | `Hello World`     | Echoed back in the output. If starts with 'fail', an error will be thrown. |
-
-### Output
-
-```json
-{
-  "result":{
-    "myProperty":"Message received: ..."
-  }
-}
+java.lang.NoSuchMethodError: com.fasterxml.jackson.databind.ObjectMapper.setSerializationInclusion(...)
 ```
 
-### Error codes
+See the [maven-shade docs on relocation](https://maven.apache.org/plugins/maven-shade-plugin/examples/class-relocation.html).
 
-| Code | Description                                |
-|------|--------------------------------------------|
-| FAIL | Message starts with 'fail' (ignoring case) |
+---
 
-## Test locally
+## Run locally
 
-Run unit tests
+You have three paths, in increasing fidelity to production:
+
+### Local Connector Runtime (recommended for development)
+
+`src/test/java/io/camunda/example/LocalConnectorRuntime.java` is a small Spring Boot app that
+starts the connector runtime in-process and points it at a Zeebe gateway you supply.
+
+**macOS / Linux:**
+```bash
+mvn test-compile exec:java -Dexec.mainClass=io.camunda.example.LocalConnectorRuntime \
+  -Dexec.classpathScope=test
+```
+
+**Windows (PowerShell):**
+```powershell
+mvn test-compile exec:java "-Dexec.mainClass=io.camunda.example.LocalConnectorRuntime" `
+  "-Dexec.classpathScope=test"
+```
+
+**Windows (cmd):**
+```cmd
+mvn test-compile exec:java -Dexec.mainClass=io.camunda.example.LocalConnectorRuntime -Dexec.classpathScope=test
+```
+
+Configure the Zeebe target in `src/test/resources/application.properties`. Without it, the runtime
+falls back to the embedded test broker spun up by the integration tests.
+
+### Bundled Docker runtime (closer to production)
+
+For an environment closer to what runs in self-managed:
 
 ```bash
-mvn clean verify
-```
-
-## Testing
-### Unit and Integration Tests
-
-You can run the unit and integration tests by executing the following Maven command:
-```bash
-mvn clean verify
-```
-
-### Local environment
-
-#### Prerequisites
-You will need the following tools installed on your machine:
-1. Camunda Modeler, which is available in two variants:
-    - [Desktop Modeler](https://camunda.com/download/modeler/) for a local installation.
-    - [Web Modeler](https://modeler.camunda.io/) for an online experience.
-
-2. [Docker](https://www.docker.com/products/docker-desktop), which is required to run the Camunda platform.
-
-#### Setting Up the Camunda platform
-
-The Connectors Runtime requires a running Camunda platform to interact with. To set up a local Camunda environment, follow these steps:
-
-1. Clone the [Camunda distributions repository](https://github.com/camunda/camunda-distributions) from GitHub and navigate to the Camunda 8.8 docker-compose directory:
-
-```shell
 git clone git@github.com:camunda/camunda-distributions.git
-cd cd docker-compose/versions/camunda-8.8
-```
-
-**Note:** This template is compatible with Camunda 8.8. Using other versions may lead to compatibility issues.
-
-Either comment out the connectors service, or use the `--scale` flag to exclude it:
-
-```shell
+cd camunda-distributions/docker-compose/versions/camunda-8.9
+# either comment out the connectors service in docker-compose-core.yaml,
+# or scale it to zero so the runtime you start locally is the one picking up jobs:
 docker compose -f docker-compose-core.yaml up --scale connectors=0
 ```
 
-#### Configure the Desktop Modeler and Use Your Connector
+Then start `LocalConnectorRuntime` as above. Operate is at http://localhost:8088/operate
+(`demo` / `demo`).
 
-Add the `element-templates/my-connector.json` to your Modeler configuration as per
-the [Element Templates documentation](https://docs.camunda.io/docs/components/modeler/desktop-modeler/element-templates/configuring-templates/).
+> **Note**: this template targets Camunda **8.9.x**. Pin distributions to the matching minor —
+> running against a different minor will surface as deserialization errors or incident messages
+> about unknown headers.
 
-#### Using Your Connector
-Then, to use your connector in a local Camunda environment, follow these steps:
+### SaaS
 
-1. Run the [`io.camunda.example.LocalConnectorRuntime`](src/test/java/io/camunda/example/LocalConnectorRuntime.java) to start your connector for testing purposes.
-2. Open the Camunda Desktop Modeler and create a new BPMN diagram.
-3. Design a process that incorporates your newly created connector.
-4. Deploy the process to your local Camunda platform.
-5. Verify that the process is running smoothly by accessing Camunda Operate at [localhost:8088/operate](http://localhost:8088/operate). Username and password are both `demo`.
+1. https://console.camunda.io → create a cluster (latest 8.9 patch).
+2. **API → Create new Client**, tick `Zeebe`, **Create**.
+3. Copy the **Spring Boot** snippet into `src/test/resources/application.properties`.
+4. Start `LocalConnectorRuntime` — the connector connects to your SaaS cluster.
+5. In Web Modeler: create a project → **Create new** → **Upload files** → upload your
+   `element-templates/<your-template>.json` → **Publish**. Then create a BPMN diagram in the same
+   project and use the connector.
 
-### SaaS environment
+---
 
-#### Creating an API Client
+## Testing
 
-The Connectors Runtime (LocalConnectorRuntime) requires connection details to interact with your Camunda SaaS cluster. To set this up, follow these steps:
+Three layers, all run by `mvn clean verify`:
 
-1. Navigate to Camunda [SaaS](https://console.camunda.io).
-2. Create a cluster using the latest version available.
-3. Select your cluster, then go to the `API` section and click `Create new Client`.
-4. Ensure the `zeebe` checkbox is selected, then click `Create`.
-5. Copy the configuration details displayed under the `Spring Boot` tab.
-6. Paste the copied configuration into your `application.properties` file within your project.
+| Layer | File | Purpose |
+|---|---|---|
+| Unit (no runtime) | [`MyConnectorTest`](src/test/java/io/camunda/example/MyConnectorTest.java) | Happy-path test using `OutboundConnectorContextBuilder` from `connector-runtime-test`. Compiles and passes out-of-the-box. |
+| Unit (no runtime) | [`ProcessDocumentTest`](src/test/java/io/camunda/example/ProcessDocumentTest.java) | Direct method-call tests of `processDocument` — small/large documents, size limits. |
+| Integration | [`MyConnectorIntegrationTest`](src/test/java/io/camunda/example/integration/MyConnectorIntegrationTest.java) | Spins up an embedded Camunda + connector runtime and runs a real BPMN process via `@CamundaSpringProcessTest`. |
 
-#### Using Your Connector
+The minimal pattern for unit-testing an annotations-based connector:
 
-1. Start your connector by executing `io.camunda.example.LocalConnectorRuntime` in your development
-   environment.
-2. Access the Web Modeler and create a new project.
-3. Click on `Create new`, then select `Upload files`. Upload the connector template from the repository you have.
-4. After uploading, **publish the connector template** by clicking the Publish button.
-5. In the same folder, create a new BPMN diagram.
-6. Design and start a process that incorporates your new connector.
+```java
+var connector = new MyConnector();
+var operations = ConnectorOperations.from(connector, new ObjectMapper(), new DefaultValidationProvider());
+var function = new OutboundConnectorOperationFunction(operations);
 
-## Element Template
+var context = OutboundConnectorContextBuilder.create()
+    .variables(Map.of("message", "hi", "authentication", Map.of("user","u","token","t")))
+    .header("operation", "echo")  // selects which @Operation to dispatch
+    .build();
 
-The element template for this sample connector is generated automatically based on the connector
-input class using
-the [Element Template Generator](https://github.com/camunda/connectors/tree/main/element-template-generator/core).
+Object result = function.execute(context);
+```
 
-The generation is embedded in the Maven build and can be triggered by running `mvn clean package`.
+The `operation` custom header is what the runtime uses to pick the `@Operation` method —
+forgetting to set it produces `Operation ID is missing in the job context custom headers.`
 
-The generated element template can be found
-in [element-templates/my-connector.json](./element-templates/my-connector.json).
+---
+
+## Document handling
+
+`processDocument` shows how to consume Camunda **documents** safely, including large ones.
+
+### Patterns demonstrated
+
+- **In-memory bytes** for small payloads — simple, fine for KBs.
+- **Streaming** for anything larger — bound memory use; never call `asByteArray()` on a multi-MiB
+  document running in a shared connector runtime.
+- **Multiple documents** — accept a `List<Document>` field on the request record.
+- **Size guarding** — read `document.metadata().getSize()` and reject anything above your limit
+  with a `ConnectorException("DOCUMENT_TOO_LARGE", ...)` *before* you start reading.
+
+### Heap and large-file guidance
+
+- The connector runtime is **shared**: every job competes for the same heap. A 200 MB
+  `asByteArray()` call can take the runtime down for every other connector at once.
+- Default to `asInputStream()` and stream into your sink (digest, S3 upload, etc.).
+- If you need temp storage, write to `Files.createTempFile(...)` and delete on completion (use
+  try-with-resources or a `finally`).
+- Pick a hard maximum (`MAX_DOCUMENT_SIZE_BYTES`) appropriate to your runtime's JVM heap — this
+  template uses 100 MiB as a placeholder.
+- Metadata (`getFileName`, `getContentType`, `getSize`, `getCustomProperties`) is cheap and
+  available without reading content; use it for routing decisions.
+
+See [`MyConnector#processDocument`](src/main/java/io/camunda/example/MyConnector.java) and
+[`ProcessDocumentTest`](src/test/java/io/camunda/example/ProcessDocumentTest.java).
+
+---
+
+## Element template — tips and do/don't
+
+The template is generated from `@TemplateProperty` annotations on your input records. A few rules
+that catch out most authors:
+
+### Do
+
+- **Typed defaults.** A boolean default is `defaultValue = "true"` with `type = PropertyType.Boolean`,
+  not the string `"true"` on a Text property. Likewise numbers must use `PropertyType.Number`.
+- **One `@Operation = one input record.** Discriminator (the `operation` header) is added by the
+  generator. Don't model it yourself.
+- **Group properties** with `@TemplateProperty(group = "...")`. Define the group label in
+  `@ElementTemplate.PropertyGroups` so it shows in the Modeler panel.
+- **Stable IDs.** `@ElementTemplate(id = "...", version = N)` — bump `version` when properties
+  change in a breaking way; keep the `id` stable so existing diagrams find their template.
+- **Icon.** SVG, square, monochrome-friendly, ~18×18 effective drawing area, no embedded fonts.
+  Reference it by classpath path: `icon = "icon.svg"`.
+
+### Don't
+
+- **Don't** declare a property called `operation` yourself — it duplicates the discriminator the
+  generator emits and the Modeler will show two "Operation" fields.
+- **Don't** put validation only at runtime. Add Bean Validation annotations (`@NotEmpty`,
+  `@NotNull`, `@Valid` on nested records) so the Modeler highlights missing values *before* deploy.
+- **Don't** hand-edit the generated JSON. Any change is wiped on the next `mvn package`. Change
+  the annotations instead.
+- **Don't** reuse property IDs between operations. Two `@TemplateProperty(id = "url")` in
+  different operations works *only* if you also set distinct `condition` blocks — easier to use
+  distinct IDs.
+
+Both should print nothing.
+
+---
+
+## Web Modeler vs Desktop Modeler
+
+| | **Desktop Modeler** | **Web Modeler** |
+|---|---|---|
+| When to use | Iterating on the connector template itself — instant reload, no upload step | Sharing with non-developers, SaaS deploy targets, collaboration |
+| Loading the template | **Settings → Element Templates → Add directory** pointing at `element-templates/` of this repo. Re-opens pick up regenerated JSON immediately | **Upload files** → select the JSON → **Publish** in the project. Re-publishing is required after every `mvn package` |
+| Deploy target | Local self-managed (Docker runtime above) | SaaS or self-managed |
+| Editing the template | The Desktop Modeler watches the directory — saving regenerates and reloads | Re-upload + re-publish per change |
+
+A common workflow: develop and validate against Desktop Modeler with the local runtime, then
+upload the same template to Web Modeler once it stabilises.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `Operation ID is missing in the job context custom headers.` | The element template wasn't applied (or you wrote a hand-rolled task) so the `operation` header isn't set | In Modeler, apply the connector template to the service task. In tests, set `.header("operation", "<id>")`. |
+| `No connector function found for type 'io.camunda:example:1'` | Runtime doesn't see your connector | Check that the SPI file `META-INF/services/io.camunda.connector.api.outbound.OutboundConnectorProvider` contains the FQ class name and is on the classpath of the runtime |
+| `NullPointerException ... ValidationProvider.validate` in unit tests | Passed `null` to `ConnectorOperations.from(...)` | Pass `new DefaultValidationProvider()` (from `io.camunda.connector:connector-validation`) |
+| `IncompatibleClassChangeError` against the runtime | Built against one minor, deployed against another | Match the SDK version (`<version.connectors>`) to the runtime minor |
+
+---
+
+## Versions and compatibility
+
+This template currently pins:
+
+| Component | Version | Property in `pom.xml` |
+|---|---|---|
+| Connector SDK & runtime libs | `8.9.0` | `version.connectors` |
+| Camunda process-test | `8.9.0` | `version.camunda` |
+| Java | 21 | `maven.compiler.release` |
+| JUnit Jupiter | `6.0.2` | `version.junit-jupiter` |
+| AssertJ | `3.27.4` | `version.assertj` |
+| Mockito | `5.21.0` | `version.mockito` |
+
+**Compatibility matrix**
+
+| Connector SDK | Camunda runtime | Modeler (Desktop) | Modeler (Web) |
+|---|---|---|---|
+| `8.9.x` | `8.9.x` self-managed or SaaS | latest | latest |
+| `8.8.x` | `8.8.x` | latest | latest |
+
+Rule of thumb: the SDK's *minor* must match the connector runtime's minor. Patch versions are
+freely swappable. When you upgrade, bump `version.connectors`, `version.camunda`, and the
+`element-template-generator-maven-plugin` `version` together.
+
+---
+
+## API reference (this template)
+
+### `echo` — Echo message
+
+| Name | Description | Example | Notes |
+|---|---|---|---|
+| `message` | Message text | `Hello World` | Echoed back. Starting with `fail` raises a non-retryable `FAIL` error; starting with `retry` raises a retryable `RETRY` error. |
+| `authentication.user` | Mock username | `alice` | No effect, demo only. |
+| `authentication.token` | Mock token | `s3cret` | No effect, demo only. |
+
+Output: `{ "result": { "myProperty": "Message received: ..." } }`
+
+### `addTwoNumbers`
+
+`A + B` (both `int`).
+
+### `processDocument`
+
+| Name | Description |
+|---|---|
+| `document` | Camunda document reference (bound automatically) |
+| `additionalDocuments` | Optional list of further documents |
+
+Output: `{ fileName, contentType, size, sha256, strategy, additionalDocumentCount }` where
+`strategy` is `"in-memory"` or `"stream"` depending on the document size.
+
+### Error codes
+
+| Code | Operation | Description |
+|---|---|---|
+| `FAIL` | `echo` | Message starts with `fail` |
+| `RETRY` | `echo` | Message starts with `retry` (decremented retries) |
+| `DOCUMENT_TOO_LARGE` | `processDocument` | Document size exceeds `MAX_DOCUMENT_SIZE_BYTES` |
+| `DOCUMENT_READ_FAILED` | `processDocument` | I/O error while reading the document stream |
+
+---
+
+More: [Connectors SDK source](https://github.com/camunda/connectors) ·
+[Custom Connector docs](https://docs.camunda.io/docs/components/connectors/custom-built-connectors/connector-sdk/)

--- a/element-templates/my-connector.json
+++ b/element-templates/my-connector.json
@@ -17,6 +17,9 @@
     "value" : "bpmn:ServiceTask"
   },
   "groups" : [ {
+    "id" : "document",
+    "label" : "Document"
+  }, {
     "id" : "message",
     "label" : "Message"
   }, {
@@ -45,6 +48,25 @@
       "type" : "zeebe:taskDefinition"
     },
     "type" : "Hidden"
+  }, {
+    "id" : "processDocument:additionalDocuments",
+    "label" : "Additional documents",
+    "description" : "Optional list of further documents processed alongside the primary one.",
+    "optional" : true,
+    "feel" : "optional",
+    "group" : "document",
+    "binding" : {
+      "name" : "additionalDocuments",
+      "type" : "zeebe:input"
+    },
+    "condition" : {
+      "allMatch" : [ {
+        "property" : "operation",
+        "equals" : "processDocument",
+        "type" : "simple"
+      } ]
+    },
+    "type" : "String"
   }, {
     "id" : "echo:message",
     "label" : "Message",
@@ -83,6 +105,9 @@
     }, {
       "name" : "Echo message",
       "value" : "echo"
+    }, {
+      "name" : "Process document",
+      "value" : "processDocument"
     } ]
   }, {
     "id" : "addTwoNumbers:A",

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <version.connectors>8.9.0</version.connectors>
+    <version.connectors>8.9.1</version.connectors>
     <version.camunda>8.9.0</version.camunda>
     <version.assertj>3.27.4</version.assertj>
     <version.junit-jupiter>6.0.2</version.junit-jupiter>

--- a/src/main/java/io/camunda/example/MyConnector.java
+++ b/src/main/java/io/camunda/example/MyConnector.java
@@ -3,16 +3,26 @@ package io.camunda.example;
 import io.camunda.connector.api.annotation.Operation;
 import io.camunda.connector.api.annotation.OutboundConnector;
 import io.camunda.connector.api.annotation.Variable;
+import io.camunda.connector.api.document.Document;
 import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.error.ConnectorRetryExceptionBuilder;
 import io.camunda.connector.api.outbound.OutboundConnectorProvider;
 import io.camunda.connector.generator.java.annotation.ElementTemplate;
+import io.camunda.example.model.DocumentProcessRequest;
+import io.camunda.example.model.DocumentProcessResponse;
 import io.camunda.example.model.EchoRequest;
 import io.camunda.example.model.EchoResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Optional;
 
 @OutboundConnector(name = "My Connector", type = "io.camunda:example:1")
 @ElementTemplate(
@@ -53,5 +63,70 @@ public class MyConnector implements OutboundConnectorProvider {
   @Operation(id = "addTwoNumbers", name = "Add two numbers")
   public Object addTwoNumbers(@Variable(name = "A") int a, @Variable(name = "B") int b) {
     return a + b;
+  }
+
+  // Documents above this size are streamed to avoid loading the entire payload into the
+  // shared connector-runtime heap. Tune to your runtime's heap budget.
+  static final long IN_MEMORY_THRESHOLD_BYTES = 1L * 1024 * 1024; // 1 MiB
+  // Hard ceiling: refuse anything larger so a single job cannot exhaust the runtime.
+  static final long MAX_DOCUMENT_SIZE_BYTES = 100L * 1024 * 1024; // 100 MiB
+
+  @Operation(id = "processDocument", name = "Process document")
+  public DocumentProcessResponse processDocument(@Variable DocumentProcessRequest request) {
+    Document doc = request.document();
+    long size = Optional.ofNullable(doc.metadata().getSize()).orElse(-1L);
+
+    if (size > MAX_DOCUMENT_SIZE_BYTES) {
+      throw new ConnectorException(
+          "DOCUMENT_TOO_LARGE",
+          "Document size " + size + " exceeds limit " + MAX_DOCUMENT_SIZE_BYTES);
+    }
+
+    String strategy;
+    String sha256;
+    if (size >= 0 && size <= IN_MEMORY_THRESHOLD_BYTES) {
+      // Small documents: in-memory bytes are simple and fine.
+      strategy = "in-memory";
+      sha256 = sha256(doc.asByteArray());
+    } else {
+      // Large or unknown size: stream to bound memory use.
+      strategy = "stream";
+      sha256 = sha256Stream(doc.asInputStream());
+    }
+
+    List<Document> additional = Optional.ofNullable(request.additionalDocuments()).orElse(List.of());
+    return new DocumentProcessResponse(
+        doc.metadata().getFileName(),
+        doc.metadata().getContentType(),
+        size,
+        sha256,
+        strategy,
+        additional.size());
+  }
+
+  private static String sha256(byte[] bytes) {
+    return HexFormat.of().formatHex(newSha256().digest(bytes));
+  }
+
+  private static String sha256Stream(InputStream in) {
+    MessageDigest digest = newSha256();
+    byte[] buf = new byte[8 * 1024];
+    try (InputStream stream = in) {
+      int read;
+      while ((read = stream.read(buf)) != -1) {
+        digest.update(buf, 0, read);
+      }
+    } catch (IOException e) {
+      throw new ConnectorException("DOCUMENT_READ_FAILED", "Failed to read document stream", e);
+    }
+    return HexFormat.of().formatHex(digest.digest());
+  }
+
+  private static MessageDigest newSha256() {
+    try {
+      return MessageDigest.getInstance("SHA-256");
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 not available", e);
+    }
   }
 }

--- a/src/main/java/io/camunda/example/model/DocumentProcessRequest.java
+++ b/src/main/java/io/camunda/example/model/DocumentProcessRequest.java
@@ -1,0 +1,22 @@
+package io.camunda.example.model;
+
+import io.camunda.connector.api.document.Document;
+import io.camunda.connector.generator.java.annotation.TemplateProperty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record DocumentProcessRequest(
+    @NotNull
+    @TemplateProperty(
+        group = "document",
+        label = "Document",
+        description = "The document to process. Bound automatically from a process variable holding a document reference.")
+    Document document,
+
+    @TemplateProperty(
+        group = "document",
+        label = "Additional documents",
+        description = "Optional list of further documents processed alongside the primary one.",
+        optional = true)
+    List<Document> additionalDocuments) {}

--- a/src/main/java/io/camunda/example/model/DocumentProcessResponse.java
+++ b/src/main/java/io/camunda/example/model/DocumentProcessResponse.java
@@ -1,0 +1,9 @@
+package io.camunda.example.model;
+
+public record DocumentProcessResponse(
+    String fileName,
+    String contentType,
+    long size,
+    String sha256,
+    String strategy,
+    int additionalDocumentCount) {}

--- a/src/test/java/io/camunda/example/MyConnectorTest.java
+++ b/src/test/java/io/camunda/example/MyConnectorTest.java
@@ -1,0 +1,42 @@
+package io.camunda.example;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.runtime.core.outbound.operation.ConnectorOperations;
+import io.camunda.connector.runtime.core.outbound.operation.OutboundConnectorOperationFunction;
+import io.camunda.connector.runtime.test.outbound.OutboundConnectorContextBuilder;
+import io.camunda.connector.validation.impl.DefaultValidationProvider;
+import io.camunda.example.model.EchoResponse;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Happy-path unit test for the annotations-based connector using the standard
+ * {@link OutboundConnectorContextBuilder}. The {@code operation} custom header
+ * selects which {@code @Operation} method is dispatched.
+ */
+class MyConnectorTest {
+
+  @Test
+  void echoOperation_returnsExpectedResponse() {
+    var connector = new MyConnector();
+    var operations =
+        ConnectorOperations.from(connector, new ObjectMapper(), new DefaultValidationProvider());
+    var function = new OutboundConnectorOperationFunction(operations);
+
+    var context =
+        OutboundConnectorContextBuilder.create()
+            .variables(Map.of(
+                "message", "hello",
+                "authentication", Map.of("user", "alice", "token", "t-123")))
+            .header("operation", "echo")
+            .build();
+
+    Object result = function.execute(context);
+
+    assertThat(result).isInstanceOf(EchoResponse.class);
+    assertThat(((EchoResponse) result).myProperty()).isEqualTo("Message received: hello");
+  }
+}

--- a/src/test/java/io/camunda/example/ProcessDocumentTest.java
+++ b/src/test/java/io/camunda/example/ProcessDocumentTest.java
@@ -1,0 +1,121 @@
+package io.camunda.example;
+
+import io.camunda.connector.api.document.Document;
+import io.camunda.connector.api.document.DocumentLinkParameters;
+import io.camunda.connector.api.document.DocumentMetadata;
+import io.camunda.connector.api.document.DocumentReference;
+import io.camunda.connector.api.error.ConnectorException;
+import io.camunda.example.model.DocumentProcessRequest;
+import io.camunda.example.model.DocumentProcessResponse;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.time.OffsetDateTime;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ProcessDocumentTest {
+
+  private final MyConnector connector = new MyConnector();
+
+  @Test
+  void smallDocument_processedInMemory() {
+    byte[] content = "hello world".getBytes();
+    var doc = new TestDocument(content, "hello.txt", "text/plain", (long) content.length);
+
+    DocumentProcessResponse response =
+        connector.processDocument(new DocumentProcessRequest(doc, List.of()));
+
+    assertThat(response.fileName()).isEqualTo("hello.txt");
+    assertThat(response.contentType()).isEqualTo("text/plain");
+    assertThat(response.size()).isEqualTo(content.length);
+    assertThat(response.strategy()).isEqualTo("in-memory");
+    assertThat(response.sha256()).isEqualTo(expectedSha256(content));
+    assertThat(response.additionalDocumentCount()).isZero();
+  }
+
+  @Test
+  void largeDocument_processedStreaming_doesNotLoadFully() {
+    // 4 MiB > IN_MEMORY_THRESHOLD_BYTES (1 MiB) → streaming path is taken.
+    byte[] content = new byte[4 * 1024 * 1024];
+    for (int i = 0; i < content.length; i++) content[i] = (byte) (i % 251);
+    var doc = new TestDocument(content, "big.bin", "application/octet-stream", (long) content.length) {
+      @Override
+      public byte[] asByteArray() {
+        // Fail loudly if the connector takes the in-memory path on a large document.
+        throw new AssertionError("Large documents must be streamed, not loaded into memory");
+      }
+    };
+
+    DocumentProcessResponse response =
+        connector.processDocument(new DocumentProcessRequest(doc, List.of()));
+
+    assertThat(response.strategy()).isEqualTo("stream");
+    assertThat(response.size()).isEqualTo(content.length);
+    assertThat(response.sha256()).isEqualTo(expectedSha256(content));
+  }
+
+  @Test
+  void documentExceedingMaxSize_isRejected() {
+    var doc = new TestDocument(new byte[0], "huge.bin", "application/octet-stream",
+        MyConnector.MAX_DOCUMENT_SIZE_BYTES + 1);
+
+    assertThatThrownBy(() -> connector.processDocument(new DocumentProcessRequest(doc, List.of())))
+        .isInstanceOf(ConnectorException.class)
+        .extracting(t -> ((ConnectorException) t).getErrorCode())
+        .isEqualTo("DOCUMENT_TOO_LARGE");
+  }
+
+  @Test
+  void multipleDocuments_arePassedThrough() {
+    byte[] primary = "primary".getBytes();
+    var doc = new TestDocument(primary, "a.txt", "text/plain", (long) primary.length);
+    var extra1 = new TestDocument("e1".getBytes(), "e1.txt", "text/plain", 2L);
+    var extra2 = new TestDocument("e2".getBytes(), "e2.txt", "text/plain", 2L);
+
+    DocumentProcessResponse response =
+        connector.processDocument(new DocumentProcessRequest(doc, List.of(extra1, extra2)));
+
+    assertThat(response.additionalDocumentCount()).isEqualTo(2);
+  }
+
+  private static String expectedSha256(byte[] bytes) {
+    try {
+      return HexFormat.of()
+          .formatHex(java.security.MessageDigest.getInstance("SHA-256").digest(bytes));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /** Minimal in-memory Document for unit tests — avoids spinning up a runtime. */
+  private static class TestDocument implements Document {
+    private final byte[] content;
+    private final DocumentMetadata metadata;
+
+    TestDocument(byte[] content, String fileName, String contentType, Long declaredSize) {
+      this.content = content;
+      this.metadata = new DocumentMetadata() {
+        @Override public String getContentType() { return contentType; }
+        @Override public OffsetDateTime getExpiresAt() { return null; }
+        @Override public Long getSize() { return declaredSize; }
+        @Override public String getFileName() { return fileName; }
+        @Override public String getProcessDefinitionId() { return null; }
+        @Override public Long getProcessInstanceKey() { return null; }
+        @Override public Map<String, Object> getCustomProperties() { return Map.of(); }
+      };
+    }
+
+    @Override public DocumentMetadata metadata() { return metadata; }
+    @Override public String asBase64() { return java.util.Base64.getEncoder().encodeToString(content); }
+    @Override public InputStream asInputStream() { return new ByteArrayInputStream(content); }
+    @Override public byte[] asByteArray() { return content; }
+    @Override public DocumentReference reference() { return null; }
+    @Override public String generateLink(DocumentLinkParameters params) { return null; }
+  }
+}


### PR DESCRIPTION
This pull request introduces a new "Process document" operation to the connector, enabling it to process documents with efficient memory management and support for multiple documents. It adds input validation, streaming for large files, and comprehensive tests for document processing scenarios. Additionally, the connector dependencies are updated.

**New document processing operation:**

* Added a new `processDocument` operation in `MyConnector` that processes a primary document and an optional list of additional documents, selecting between in-memory or streaming processing based on file size, and enforcing a maximum document size limit.
* Introduced the `DocumentProcessRequest` and `DocumentProcessResponse` record classes to model the request and response for the new operation. [[1]](diffhunk://#diff-861b0d3d8d45f3310c1665c8dbcda861e49de0d0fa5fbf72293280c25b48b89eR1-R22) [[2]](diffhunk://#diff-2e17c87ad22e5ee7e753522f2ede7885ca7b3694936f1b5ed3d735572a59e18bR1-R9)

**Element template and configuration updates:**

* Updated `my-connector.json` to add a new "document" group, support for the new "Process document" operation, and a property for specifying additional documents. [[1]](diffhunk://#diff-81c70eb816b2db5081c03b57069c1d7e12f2863cda4b7437381f17a45f617be8R20-R22) [[2]](diffhunk://#diff-81c70eb816b2db5081c03b57069c1d7e12f2863cda4b7437381f17a45f617be8R51-R69) [[3]](diffhunk://#diff-81c70eb816b2db5081c03b57069c1d7e12f2863cda4b7437381f17a45f617be8R108-R110)

**Testing improvements:**

* Added `ProcessDocumentTest` to cover small, large, oversized, and multiple document scenarios for the new operation, including memory usage and error handling.
* Added a basic happy-path test for the existing `echo` operation.

**Dependency updates:**

* Upgraded the connectors version in `pom.xml` from `8.9.0` to `8.9.1`.

